### PR TITLE
Updated build workflow

### DIFF
--- a/.github/workflows/build-openssl.yml
+++ b/.github/workflows/build-openssl.yml
@@ -517,7 +517,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: openssl-${{ github.event.inputs.version }}-${{ matrix.arch }}
+          name: openssl-${{ github.event.inputs.version }}-${{ matrix.os-label }}-${{ matrix.arch }}
           compression-level: 0 
           path: |
             ${{ github.workspace }}/openssl-*.zip


### PR DESCRIPTION
Improves POSIX builds with:
- makes library loaded with library `origin` path, but not with path defined in `prefix` build config parameter
- changes `OPENSSLDIR` to platform default path
Fixes #10 