### PR TITLE
Publishing workflow update

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,6 +21,9 @@ on:
     workflows: ["Build OpenSSL 3.x"]
     types:
       - completed
+    branches:
+      - main
+      - workflows_dev
 
 permissions:
   contents: write


### PR DESCRIPTION
Now publishing workflow can be triggered by Build workflow event producing Release(s) Draft(s) automatically.

Fixes #13 