### PR TITLE
Add dynamic workflow nane

### DIFF
--- a/.github/workflows/build-openssl.yml
+++ b/.github/workflows/build-openssl.yml
@@ -1,4 +1,5 @@
 name: Build OpenSSL 3.x
+run-name: Build OpenSSL ${{ inputs.version }} via ${{ github.event_name }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Cusrrent build workflow has a static generic name. Adding dynamic name in format of
"Build OpenSSL ${{ inputs.version }} via ${{ github.event_name }}" improves visibility