### PR TITLE
Allow trigger run only from main branch

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,7 +23,6 @@ on:
       - completed
     branches:
       - main
-      - workflow_dev
 
 permissions:
   contents: write


### PR DESCRIPTION
We do not need trigger the `publish-release.yml` workflow from any other branch than `main`.