### PR TITLE
Set `minos` version for MacOS static libs

### DIFF
--- a/.github/workflows/build-openssl.yml
+++ b/.github/workflows/build-openssl.yml
@@ -241,6 +241,12 @@ jobs:
           elif [ "${{ matrix.os-label }}" == "iOS" ]; then
             export CROSS_TOP=$(xcode-select -p)/Platforms/iPhoneOS.platform/Developer
             export CROSS_SDK=iPhoneOS.sdk
+          elif [ "${{ matrix.os-label }}" == "macOS" ]; then
+            if [ "${{ matrix.arch }}" == "arm64" ]; then
+              EXTRA_FLAGS="-mmacosx-version-min=11.0"
+            elif [ "${{ matrix.arch }}" == "x64" ]; then
+              EXTRA_FLAGS="-mmacosx-version-min=10.14"
+            fi
           fi
           
           # Try with no-apps (3.2+), fallback to without no-apps (3.0/3.1)


### PR DESCRIPTION
Delphi 13 generates 900+ hints when link `libcrypto.a` and `libssl.a`. It wants the `minos` version `11.0` or lower for `OSX64ARM` and `10.14` or lower for `OSX64` targets.

Fixes #50 