### PR TITLE
actions/checkout version changed to 6.0

### DIFF
--- a/.github/workflows/build-openssl.yml
+++ b/.github/workflows/build-openssl.yml
@@ -74,7 +74,7 @@ jobs:
     needs: validate-version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: openssl/openssl
           ref: openssl-${{ needs.validate-version.outputs.version }}
@@ -123,7 +123,7 @@ jobs:
             
     runs-on: ${{ matrix.platform.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: openssl/openssl
           ref: openssl-${{ needs.validate-version.outputs.version }}
@@ -250,7 +250,7 @@ jobs:
           
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Download Common Assets
         uses: actions/download-artifact@v4

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Fetch Active OpenSSL Versions
         id: fetch_versions

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -52,7 +52,7 @@ jobs:
           fi
 
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Download Build Metadata
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Action `actions/checkout@v4` will be deprecated soon It's upgraded to `actions/checkout@v6`

Quick check passed.