### PR TITLE
Fix: Check Upstream to extract alfa and beta

### DIFF
--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -76,7 +76,7 @@ jobs:
             
             # Find the latest tag for this cycle using ls-remote
             # OpenSSL tags follow 'openssl-<version>' pattern
-            LATEST_TAG=$(git ls-remote --tags "$SOURCE_REPO" "openssl-${cycle}.*" | awk -F/ '{print $3}' | grep -v "\^{}" | sort -V | tail -n1)
+            LATEST_TAG=$(git ls-remote --tags "$SOURCE_REPO" "openssl-${cycle}.*" | awk -F/ '{print $3}' | grep -P "openssl-\d{1,}.\d{1,}.\d{1,}$" | sort -V | tail -n1)
             
             if [ -z "$LATEST_TAG" ]; then
               echo "⚠️ No tags found matching openssl-${cycle}.* skipping."


### PR DESCRIPTION
This fix resolves issues when the fresh OpenSSL `openssl-X.Y.Z-alfaN` or `openssl-X.Y.Z-betaN` tag is treated as a new OpenSSL Release and triggers its building.
This fix check only OpenSSL tags with format: `openssl-X*.Y*.Z*`  