### PR TITLE
Include ELUA screen to interactive installer

### DIFF
--- a/.github/workflows/build-openssl.yml
+++ b/.github/workflows/build-openssl.yml
@@ -436,7 +436,7 @@ jobs:
 
       - name: Azure Login
         if: matrix.platform.label == 'Windows' && steps.check_binaries.outputs.has_binaries == 'true'
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
 
@@ -754,7 +754,7 @@ jobs:
           Write-Host "✅ Multi-Arch InnoSetup installer compiled."
 
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
 
@@ -911,7 +911,7 @@ jobs:
           Write-Host "✅ Framework MSIX created: $msixOut"
 
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
 

--- a/.github/workflows/build-openssl.yml
+++ b/.github/workflows/build-openssl.yml
@@ -1184,31 +1184,6 @@ jobs:
           name: build-metadata
           path: dist/version.txt
           retention-days: 5
-      - name: Download Windows Installers
-        if: matrix.label == 'Windows' && needs.validate-version.outputs.is_fork == 'false' && inputs.build_type == 'release'
-        uses: actions/download-artifact@v8
-        with:
-          pattern: raw-installer-*-${{ matrix.arch }}-${{ github.run_id }}
-          path: installers
-          merge-multiple: true
-
-      - name: Upload Final MSIX Installer
-        if: matrix.label == 'Windows' && needs.validate-version.outputs.is_fork == 'false' && inputs.build_type == 'release'
-        uses: actions/upload-artifact@v7
-        with:
-          name: openssl-${{ needs.validate-version.outputs.artifact_version }}-Windows-${{ matrix.arch }}-msix
-          path: installers/openssl-${{ needs.validate-version.outputs.version }}-Windows-${{ matrix.arch }}.msix
-          archive: false
-          retention-days: 5
-
-      - name: Upload Final InnoSetup Installer
-        if: matrix.label == 'Windows' && needs.validate-version.outputs.is_fork == 'false' && inputs.build_type == 'release'
-        uses: actions/upload-artifact@v7
-        with:
-          name: openssl-${{ needs.validate-version.outputs.artifact_version }}-Windows-${{ matrix.arch }}-installer
-          path: installers/openssl-${{ needs.validate-version.outputs.version }}-Windows-${{ matrix.arch }}-installer.exe
-          archive: false
-          retention-days: 5
 
   # =========================================================================
   # 5. CLEANUP RAW ARTIFACTS

--- a/config/openssl-installer.iss.template
+++ b/config/openssl-installer.iss.template
@@ -16,6 +16,7 @@ OutputDir={{OUTPUT_DIR}}
 OutputBaseFilename={{OUTPUT_BASE_FILENAME}}
 Compression=lzma2/ultra64
 SolidCompression=yes
+LicenseFile={{REDIST_DIR}}\LICENSE.txt
 PrivilegesRequired=lowest
 PrivilegesRequiredOverridesAllowed=dialog commandline
 DisableProgramGroupPage=yes


### PR DESCRIPTION
The OpenSSL require presenting the license agreement with redistributable code and binaries.
We deploy the `LICENSE.TXT` file with the binaries/executables, but we do not display it explicitly with the interactive installations.
This PR adds the ELUA screen with the interactive installation from the `openssl-<version>-Windows-installer.exe`.
Installer's ELUA screen display the OpenSSL `LICENSE.TXT` content. 

Fixes #128 